### PR TITLE
Sttings for group-LDAP-filter and additional group-contexts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,20 @@ language: php
 
 addons:
   postgresql: "9.5"
-  firefox: "47.0.1"
   apt:
     packages:
       - ldap-utils
       - slapd
-      - openjdk-8-jre-headless
+
+services:
+  - mysql
+  - postgresql
+  - docker
 
 cache:
   directories:
     - $HOME/.composer/cache
     - $HOME/.npm
-
-services:
- - mysql
 
 env:
   global:
@@ -23,22 +23,19 @@ env:
 
 matrix:
   include:
-    - php: 7.0
-      env: DB=pgsql MOODLE_BRANCH=MOODLE_36_STABLE NODE_VERSION=8.9.0
+    - php: 7.1
+      env: DB=pgsql MOODLE_BRANCH=MOODLE_37_STABLE
     - php: 7.3
-      env: DB=mysqli MOODLE_BRANCH=MOODLE_37_STABLE NODE_VERSION=14.2.0
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_38_STABLE
     - php: 7.3
-      env: DB=pgsql MOODLE_BRANCH=MOODLE_38_STABLE NODE_VERSION=14.2.0
+      env: DB=pgsql MOODLE_BRANCH=MOODLE_39_STABLE
     - php: 7.3
-      env: DB=mysqli MOODLE_BRANCH=master NODE_VERSION=14.2.0
+      env: DB=mysqli MOODLE_BRANCH=master
 
 before_install:
   - phpenv config-rm xdebug.ini
-  - nvm install $NODE_VERSION
-  - nvm use $NODE_VERSION
   - cd ../..
-  - composer selfupdate
-  - composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci ^2
+  - composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
 
 install:
@@ -64,5 +61,6 @@ script:
   - moodle-plugin-ci savepoints
   - moodle-plugin-ci mustache
   - moodle-plugin-ci grunt
+  - moodle-plugin-ci phpdoc
   - moodle-plugin-ci phpunit
   - moodle-plugin-ci behat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Change default branch to "main"
+- Update CI tool to version 3
+- Dropped support for Moodle 3.6
+
 ## 3.6.0 (June 15, 2020)
 
 - Code cleanup

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This plugin synchronizes Moodle cohorts against an LDAP directory using either g
 
 Requirements
 ------------
-- Moodle 3.6 (build 2018120300 or later)
+- Moodle 3.7 (build 2019052000 or later)
 - OpenLDAP or Active Directory
 
 Installation

--- a/lang/de/local_ldap.php
+++ b/lang/de/local_ldap.php
@@ -52,3 +52,5 @@ $string['synccohortgroup_info'] = '';
 $string['synccohortgroup'] = 'Moodle-Gruppen mit LDAP-Gruppen synchronisieren';
 $string['group_filter'] = 'LDAP-filter für Gruppen';
 $string['group_filter_desc'] = 'LDAP-Filter zum eingrenzen von Gruppen';
+$string['group_context'] = 'Zusätzliche Gruppen-OU\'s';
+$string['group_context_desc'] = 'Angeben von zusätzlichen OU\'s für die Gruppensuche. (Mit ";" separiert.)';

--- a/lang/de/local_ldap.php
+++ b/lang/de/local_ldap.php
@@ -1,0 +1,54 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * local_ldap language strings.
+ *
+ * @package   local_ldap
+ * @copyright 2013 Patrick Pollet
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['attributesynctask'] = 'Synchronisieren von Moodle-Gruppen anhand von LDAP-Attributen';
+$string['cohort_synching_ldap_attribute_attribute_desc'] = 'Anpassen des zu suchenden LDAP Benutzer-Attributs (Case-Sensitive)';
+$string['cohort_synching_ldap_attribute_attribute'] = 'Zu suchender Attributname';
+$string['cohort_synching_ldap_attribute_autocreate_cohorts_desc'] = 'Wenn aktiv werden Moodle-Gruppen automatisch angelegt';
+$string['cohort_synching_ldap_attribute_autocreate_cohorts'] = 'Fehlende Moodle-Gruppen anlegen';
+$string['cohort_synching_ldap_attribute_idnumbers_desc'] = 'Komma separierte Liste mit anzuwendenen Moodle-Gruppen-ID Nummern; Wenn leer werden alle eindeutigen Werte des Attributs für die synchronisierte Moodle-Gruppe verwendet';
+$string['cohort_synching_ldap_attribute_idnumbers'] = 'Gesuchte Moodle-Gruppen-ID Nummer';
+$string['cohort_synching_ldap_attribute_objectclass_desc'] = 'Überschreiben der Standard "ObjectClass" Einstellung (Vererbt aus den Authentifizierungsmodulen LDAP oder CAS)';
+$string['cohort_synching_ldap_attribute_objectclass'] = 'Benutzer "ObjectClass"';
+$string['cohort_synching_ldap_groups_autocreate_cohorts_desc'] = 'Wenn aktiv werden Moodle-Gruppen automatisch angelegt';
+$string['cohort_synching_ldap_groups_autocreate_cohorts'] = 'Fehlende Moodle-Gruppen anlegen';
+$string['cohort_synchronized_with_attribute'] = 'Moodle-Gruppen synchronisiert mit LDAP-Attribut {$a}';
+$string['cohort_synchronized_with_group'] = 'Moodle-Gruppen synchronsiert mit LDAP-Gruppe {$a}';
+$string['group_attribute_desc'] = 'Attribut für die Gruppen Bezeichnung im LDAP, normalerweise "cn" ';
+$string['group_attribute'] = 'Gruppen Attribut';
+$string['group_class_desc'] = 'Angeben einer alternativen "ObjectClass" für die Gruppensuche im LDAP (z.B. group, groupOfNames, etc.)';
+$string['group_class'] = 'Gruppen ObjectClass';
+$string['groupsynctask'] = 'Synchronisieren von Moodle-Gruppen mit LDAP-Gruppen';
+$string['pluginname'] = 'LDAP syncing scripts';
+$string['privacy:metadata'] = 'Die "LDAP syncing scripts" speichern keine Daten.';
+$string['process_nested_groups_desc'] = 'Wenn aktiviert, werden verschachtelte LDAP-Gruppen verarbeitet.';
+$string['process_nested_groups'] = 'Verschachtelte Gruppen verarbeiten';
+$string['real_user_attribute_desc'] = 'Wenn das Benutzer-Attribut Großbuchstaben enthält (z.B. sAMAccountName) kann hier die korrekte Schhreibweise angegeben werden, wenne s nicht entsprechend in Moodle\'s CAS/LDAP Auth-Settings hinterlegt ist.';
+$string['real_user_attribute'] = 'Korrekte Benutzer "ObjectClass"';
+$string['synccohortattribute_info'] = '';
+$string['synccohortattribute'] = 'Moodle-Gruppen mit LDAP-Attributen synchronisieren';
+$string['synccohortgroup_info'] = '';
+$string['synccohortgroup'] = 'Moodle-Gruppen mit LDAP-Gruppen synchronisieren';
+$string['group_filter'] = 'LDAP-filter für Gruppen';
+$string['group_filter_desc'] = 'LDAP-Filter zum eingrenzen von Gruppen';

--- a/lang/en/local_ldap.php
+++ b/lang/en/local_ldap.php
@@ -50,3 +50,5 @@ $string['synccohortattribute_info'] = '';
 $string['synccohortattribute'] = 'Sync Moodle\'s cohorts with LDAP attribute';
 $string['synccohortgroup_info'] = '';
 $string['synccohortgroup'] = 'Sync Moodle\'s cohorts with LDAP groups';
+$string['group_filter'] = 'Group LDAP-filter';
+$string['group_filter_desc'] = 'Define LDAP-filter to narrow down LDAP groups';

--- a/lang/en/local_ldap.php
+++ b/lang/en/local_ldap.php
@@ -52,3 +52,5 @@ $string['synccohortgroup_info'] = '';
 $string['synccohortgroup'] = 'Sync Moodle\'s cohorts with LDAP groups';
 $string['group_filter'] = 'Group LDAP-filter';
 $string['group_filter_desc'] = 'Define LDAP-filter to narrow down LDAP groups';
+$string['group_context'] = 'Additional group-ou\'s';
+$string['group_context_desc'] = 'Define additional paths for your groupsearch. (seperated by ";".)';

--- a/locallib.php
+++ b/locallib.php
@@ -40,7 +40,7 @@ class local_ldap extends auth_plugin_ldap {
     /** @var array Avoid infinite loop with nested groups in 'funny' directories. */
     private $antirecursionarray;
 
-    /** @vary array Cache for found group dns. */
+    /** @var array Cache for found group dns. */
     private $groupdnscache;
 
     /**

--- a/locallib.php
+++ b/locallib.php
@@ -69,6 +69,7 @@ class local_ldap extends auth_plugin_ldap {
         $this->merge_config($extra, 'group_attribute', 'cn');
         $this->merge_config($extra, 'group_class', 'groupOfNames');
         $this->merge_config($extra, 'group_filter', '*');
+        $this->merge_config($extra, 'group_context', '');
         $this->merge_config($extra, 'process_nested_groups', 0);
         $this->merge_config($extra, 'cohort_synching_ldap_attribute_attribute', 'eduPersonAffiliation');
         $this->merge_config($extra, 'cohort_synching_ldap_attribute_idnumbers', '');
@@ -126,8 +127,8 @@ class local_ldap extends auth_plugin_ldap {
             $filter = "(&(" . $this->config->group_attribute . "=*)(objectclass=" . $this->config->group_class . "))";
         }
 
-        if (!empty($CFG->cohort_synching_ldap_groups_contexts)) {
-            $contexts = explode(';', $CFG->cohort_synching_ldap_groups_contexts);
+        if (!empty($this->config->group_context)) {
+            $contexts = array_merge(explode(';', $this->config->group_context), explode(';', $this->config->contexts));
         } else {
             $contexts = explode(';', $this->config->contexts);
         }
@@ -199,8 +200,8 @@ class local_ldap extends auth_plugin_ldap {
 
         $queryg = "(&({$this->config->group_attribute}=" . ldap_filter_addslashes(trim($group)) . ")(objectClass={$this->config->group_class}))";
 
-        if (!empty($CFG->cohort_synching_ldap_groups_contexts)) {
-            $contexts = explode(';', $CFG->cohort_synching_ldap_groups_contexts);
+        if (!empty($this->config->group_context)) {
+            $contexts = array_merge(explode(';', $this->config->group_context), explode(';', $this->config->contexts));
         } else {
             $contexts = explode(';', $this->config->contexts);
         }
@@ -297,8 +298,8 @@ class local_ldap extends auth_plugin_ldap {
 
         $size = 999;
 
-        if (!empty($CFG->cohort_synching_ldap_groups_contexts)) {
-            $contexts = explode(';', $CFG->cohort_synching_ldap_groups_contexts);
+        if (!empty($this->config->group_context)) {
+            $contexts = array_merge(explode(';', $this->config->group_context), explode(';', $this->config->contexts));
         } else {
             $contexts = explode(';', $this->config->contexts);
         }
@@ -679,6 +680,9 @@ class local_ldap extends auth_plugin_ldap {
         $filter = '';
         if($this->config->group_filter != '' || $this->config->group_filter !== '*')
             $filter = $this->config->group_filter;
+
+        if($this->config->group_filter === '')
+            $filter = '*';
 
         $ldapgroups = $this->ldap_get_grouplist($filter);
         foreach ($ldapgroups as $groupname) {

--- a/locallib.php
+++ b/locallib.php
@@ -68,6 +68,7 @@ class local_ldap extends auth_plugin_ldap {
         $extra = get_config('local_ldap');
         $this->merge_config($extra, 'group_attribute', 'cn');
         $this->merge_config($extra, 'group_class', 'groupOfNames');
+        $this->merge_config($extra, 'group_filter', '*');
         $this->merge_config($extra, 'process_nested_groups', 0);
         $this->merge_config($extra, 'cohort_synching_ldap_attribute_attribute', 'eduPersonAffiliation');
         $this->merge_config($extra, 'cohort_synching_ldap_attribute_idnumbers', '');
@@ -675,7 +676,11 @@ class local_ldap extends auth_plugin_ldap {
     public function sync_cohorts_by_group() {
         global $DB;
 
-        $ldapgroups = $this->ldap_get_grouplist();
+        $filter = '';
+        if($this->config->group_filter != '' || $this->config->group_filter !== '*')
+            $filter = $this->config->group_filter;
+
+        $ldapgroups = $this->ldap_get_grouplist($filter);
         foreach ($ldapgroups as $groupname) {
             if (!$cohort = $DB->get_record('cohort', array('idnumber' => $groupname), '*')) {
                 if (empty($this->config->cohort_synching_ldap_groups_autocreate_cohorts)) {

--- a/settings.php
+++ b/settings.php
@@ -49,6 +49,11 @@ if ($hassiteconfig) {
     $setting = new admin_setting_configtext('local_ldap/'.$name, $title, $description, '');
     $settings->add($setting);
 
+    $name = 'group_filter';
+    $title = get_string($name, 'local_ldap');
+    $description = get_string($name . '_desc', 'local_ldap');
+    $setting = new admin_setting_configtext('local_ldap/'.$name, $title,$description, false);
+
     $name = 'process_nested_groups';
     $title = get_string($name, 'local_ldap');
     $description = get_string($name.'_desc', 'local_ldap');

--- a/settings.php
+++ b/settings.php
@@ -52,7 +52,14 @@ if ($hassiteconfig) {
     $name = 'group_filter';
     $title = get_string($name, 'local_ldap');
     $description = get_string($name . '_desc', 'local_ldap');
-    $setting = new admin_setting_configtext('local_ldap/'.$name, $title,$description, false);
+    $setting = new admin_setting_configtext('local_ldap/'.$name, $title, $description, '*');
+    $settings->add($setting);
+    
+    $name = 'group_context';
+    $title = get_string($name, 'local_ldap');
+    $description = get_string($name . '_desc', 'local_ldap');
+    $setting = new admin_setting_configtext('local_ldap/'.$name, $title, $description, '');
+    $settings->add($setting);
 
     $name = 'process_nested_groups';
     $title = get_string($name, 'local_ldap');

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ldap';
-$plugin->version   = 2020061500;
+$plugin->version   = 2020091100;
 $plugin->requires  = 2019052000;
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release   = 'v3.6.0';

--- a/version.php
+++ b/version.php
@@ -26,6 +26,6 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ldap';
 $plugin->version   = 2020061500;
-$plugin->requires  = 2018120300;
+$plugin->requires  = 2019052000;
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release   = 'v3.6.0';


### PR DESCRIPTION
We came across your plugin as we were searching for a plugin to sync grades of our schools with moodle.
As we have about 70 schools to manage, we were in need of an automated way.
Your Plugin is a good oportuninty for us.

Sadly, our AD is not designed for your plugin. Schools are sorted like DC=schulen -> OU=SCHULEN -> OU= -> OU={users, groups. computers, servers}.
A group that represents a grade is next to systemgroups for our management application inside 'ou=groups'.
Furthermore users are not inside the same ou as groups.

As tasks, we needed a filter to select only our grade-Groups.
Second, we had to define an additional context for our grade-groups.

As there was a $CFG Variable for additional contexts, I added an adminpanel field and combined this value with auth_ldap contexts.

Additional there was already an option to use filter with 'ldap_get_grouplist($filter = "*")'. I just added an adminpanel field. The defined value would be processed in 'sync_cohorts_by_group()'.

I hope these changes are in interest for someone.