### PR TITLE
Revise pagination; fixes #22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ cache:
 
 env:
   global:
-    - IGNORE_NAMES=sync_test.php
-    - CODECHECKER_IGNORE_PATHS=locallib.php
+    - IGNORE_PATHS=tests/sync_test.php
+    - CODECHECKER_IGNORE_PATHS=$IGNORE_PATHS,locallib.php
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ cache:
 env:
   global:
     - IGNORE_NAMES=sync_test.php
+    - CODECHECKER_IGNORE_PATHS=locallib.php
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
   global:
     - IGNORE_PATHS=tests/sync_test.php
     - CODECHECKER_IGNORE_PATHS=$IGNORE_PATHS,locallib.php
+    - PHPCPD_IGNORE_PATHS=$IGNORE_PATHS,locallib.php
 
 matrix:
   include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update pagination for PHP 7.4
 - Change default branch to "main"
 - Update CI tool to version 3
 - Dropped support for Moodle 3.6

--- a/tests/sync_test.php
+++ b/tests/sync_test.php
@@ -534,9 +534,20 @@ class local_ldap_sync_testcase extends advanced_testcase {
                 $ldappagedresults = ldap_paged_results_supported(3, $ldapconnection);
                 $ldapcookie = '';
                 $todelete = array();
+                $servercontrols = array();
                 do {
                     if ($ldappagedresults) {
-                        ldap_control_paged_result($ldapconnection, 250, true, $ldapcookie);
+                        if (version_compare(PHP_VERSION, '7.3.0', '<')) {
+                            ldap_control_paged_result($ldapconnection, 250, true, $ldapcookie);
+                        } else {
+                            $servercontrols = array(
+                                array(
+                                    'oid' => LDAP_CONTROL_PAGEDRESULTS, 'value' => array(
+                                        'size' => 250, 'cookie' => $ldapcookie
+                                    )
+                                )
+                            );
+                        }
                     }
                     $res = ldap_search($ldapconnection, "$filter,$dn", 'cn=*', array('dn'));
                     if (!$res) {
@@ -549,7 +560,19 @@ class local_ldap_sync_testcase extends advanced_testcase {
                         }
                     }
                     if ($ldappagedresults) {
-                        ldap_control_paged_result_response($ldapconnection, $res, $ldapcookie);
+                        $ldapcookie = '';
+                        if (version_compare(PHP_VERSION, '7.3.0', '<')) {
+                            $pagedresp = ldap_control_paged_result_response($ldapconnection, $res, $ldapcookie);
+                            if ($pagedresp === false) {
+                                $ldapcookie = null;
+                            }
+                        } else {
+                            ldap_parse_result($ldapconnection, $res, $errcode, $matcheddn,
+                                $errmsg, $referrals, $controls);
+                            if (isset($controls[LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'])) {
+                                $ldapcookie = $controls[LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'];
+                            }
+                        }
                     }
                     ldap_free_result($res);
                 } while ($ldappagedresults && $ldapcookie !== null && $ldapcookie != '');
@@ -568,7 +591,17 @@ class local_ldap_sync_testcase extends advanced_testcase {
 
                 do {
                     if ($ldappagedresults) {
-                        ldap_control_paged_result($ldapconnection, 250, true, $ldapcookie);
+                        if (version_compare(PHP_VERSION, '7.3.0', '<')) {
+                            ldap_control_paged_result($ldapconnection, 250, true, $ldapcookie);
+                        } else {
+                            $servercontrols = array(
+                                array(
+                                    'oid' => LDAP_CONTROL_PAGEDRESULTS, 'value' => array(
+                                        'size' => 250, 'cookie' => $ldapcookie
+                                    )
+                                )
+                            );
+                        }
                     }
                     $res = ldap_search($ldapconnection, "$filter,$dn", 'ou=*', array('dn'));
                     if (!$res) {
@@ -581,7 +614,19 @@ class local_ldap_sync_testcase extends advanced_testcase {
                         }
                     }
                     if ($ldappagedresults) {
-                        ldap_control_paged_result_response($ldapconnection, $res, $ldapcookie);
+                        $ldapcookie = '';
+                        if (version_compare(PHP_VERSION, '7.3.0', '<')) {
+                            $pagedresp = ldap_control_paged_result_response($ldapconnection, $res, $ldapcookie);
+                            if ($pagedresp === false) {
+                                $ldapcookie = null;
+                            }
+                        } else {
+                            ldap_parse_result($ldapconnection, $res, $errcode, $matcheddn,
+                                $errmsg, $referrals, $controls);
+                            if (isset($controls[LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'])) {
+                                $ldapcookie = $controls[LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'];
+                            }
+                        }
                     }
                     ldap_free_result($res);
                 } while ($ldappagedresults && $ldapcookie !== null && $ldapcookie != '');


### PR DESCRIPTION
This is a direct copy-paste from https://tracker.moodle.org/browse/MDL-67118. It's not an ideal solution: the new functionality for pagination was introduced in PHP 7.3; the old functionality was deprecated in PHP 7.4; we need to support PHP 7.1-7.2 until Moodle 4.1. The result is a lot of code-checker and phpcd warnings. I don't know that there's any real way to avoid them; we might be able to suppress them?