### PR TITLE
New features: Ldap-filters, Groups context, Naming attribute , Delete automatics cohorts

### DIFF
--- a/classes/task/cohorts_del_task.php
+++ b/classes/task/cohorts_del_task.php
@@ -1,0 +1,59 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Scheduled task to sync cohorts based on group membership.
+ *
+ * @package   local_ldap
+ * @copyright 2016 Lafayette College ITS
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+//#<-
+namespace local_ldap\task;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->dirroot.'/local/ldap/locallib.php');
+
+/**
+ * Scheduled task to sync cohorts based on group membership.
+ *
+ * @package   local_ldap
+ * @copyright 2016 Lafayette College ITS
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class cohorts_del_task extends \core\task\scheduled_task {
+    /**
+     * Get the name of the task.
+     *
+     * @return string the name of the task
+     */
+    public function get_name() {
+         return get_string('cohortsdeltask', 'local_ldap');
+    }
+
+    /**
+     * Execute the task.
+     *
+     * @see local_ldap::del_cohorts_by_missing_group()
+     */
+    public function execute() {
+        if ($plugin = new \local_ldap()) {
+            $plugin->del_cohorts_by_missing_group();
+        }
+    }
+}
+//#->

--- a/cli/del_cohorts.php
+++ b/cli/del_cohorts.php
@@ -1,0 +1,49 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Cohort sync with LDAP groups script. This is deprecated.
+ *
+ * @package    local_ldap
+ * @copyright  2010 Patrick Pollet - based on code by Jeremy Guittirez
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+//#<-
+define('CLI_SCRIPT', true);
+
+require(__DIR__.'/../../../config.php'); // Global moodle config file.
+require_once($CFG->dirroot.'/local/ldap/locallib.php');
+require_once($CFG->libdir.'/clilib.php');
+
+// Ensure errors are well explained.
+set_debugging(DEBUG_DEVELOPER, true);
+
+if ( !is_enabled_auth('cas') && !is_enabled_auth('ldap')) {
+    cli_problem('[LOCAL LDAP] ' . get_string('pluginnotenabled', 'auth_ldap'));
+    die;
+}
+
+cli_problem('[LOCAL LDAP] The cohort sync cron has been deprecated. Please use the scheduled task instead.');
+
+// Abort execution of the CLI script if the local_ldap\task\group_sync_task is enabled.
+$taskdisabled = \core\task\manager::get_scheduled_task('local_ldap\task\cohorts_del_task');
+if (!$taskdisabled->get_disabled()) {
+    cli_error('[LOCAL LDAP] The scheduled task cohorts_del_task is enabled, the cron execution has been aborted.');
+}
+
+$localldap = new local_ldap();
+$localldap->del_cohorts_by_missing_group();
+//#->

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -25,6 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+//# Ajout cohorts_del_task
 $tasks = [
     [
         'classname' => 'local_ldap\task\attribute_sync_task',
@@ -38,6 +39,16 @@ $tasks = [
     ],
     [
         'classname' => 'local_ldap\task\group_sync_task',
+        'blocking' => 0,
+        'minute' => '0',
+        'hour' => '*',
+        'day' => '*',
+        'month' => '*',
+        'dayofweek' => '*',
+        'disabled' => 1,
+    ],
+	[
+        'classname' => 'local_ldap\task\cohorts_del_task',
         'blocking' => 0,
         'minute' => '0',
         'hour' => '*',

--- a/lang/en/local_ldap.php
+++ b/lang/en/local_ldap.php
@@ -23,30 +23,47 @@
  */
 
 $string['attributesynctask'] = 'Synchronize cohorts from LDAP attributes';
-$string['cohort_synching_ldap_attribute_attribute'] = 'Attribute name to search';
 $string['cohort_synching_ldap_attribute_attribute_desc'] = 'Adjust to the LDAP user\'s attribute to search for (respect case)';
-$string['cohort_synching_ldap_attribute_autocreate_cohorts'] = 'Autocreate missing cohorts';
+$string['cohort_synching_ldap_attribute_attribute'] = 'Attribute name to search';
 $string['cohort_synching_ldap_attribute_autocreate_cohorts_desc'] = 'If selected will create missing cohorts automatically';
-$string['cohort_synching_ldap_attribute_idnumbers'] = 'Target cohorts idnumbers';
+$string['cohort_synching_ldap_attribute_autocreate_cohorts'] = 'Autocreate missing cohorts';
 $string['cohort_synching_ldap_attribute_idnumbers_desc'] = 'A comma-separated list of target cohort idnumbers; if missing all distinct values of the attribute will produce a synced cohort';
-$string['cohort_synching_ldap_attribute_objectclass'] = 'User class';
+$string['cohort_synching_ldap_attribute_idnumbers'] = 'Target cohorts idnumbers';
 $string['cohort_synching_ldap_attribute_objectclass_desc'] = 'Use to override default value inherited from LDAP or CAS auth plugin (respect case)';
-$string['cohort_synching_ldap_groups_autocreate_cohorts'] = 'Autocreate missing cohorts';
+$string['cohort_synching_ldap_attribute_objectclass'] = 'User class';
 $string['cohort_synching_ldap_groups_autocreate_cohorts_desc'] = 'If selected will create missing cohorts automatically';
+$string['cohort_synching_ldap_groups_autocreate_cohorts'] = 'Autocreate missing cohorts';
 $string['cohort_synchronized_with_attribute'] = 'Cohort synchronized with LDAP attribute {$a}';
 $string['cohort_synchronized_with_group'] = 'Cohort synchronized with LDAP group {$a}';
-$string['group_attribute'] = 'Group attribute';
 $string['group_attribute_desc'] = 'Naming attribute of your LDAP groups, usually cn ';
-$string['group_class'] = 'Group class';
+$string['group_attribute'] = 'Group attribute';
+//#<-
+$string['cohort_synching_ldap_groups_create_cohort_name_by_attribute'] = 'Cohort_synching_ldap_groups_create_cohort_name_by_attribute';
+$string['cohort_synching_ldap_groups_create_cohort_name_by_attribute_desc'] = 'Use personalized group attribute for naming cohorts';
+$string['group_attribute_description'] = 'Group attribute description';
+$string['group_attribute_description_desc'] = 'Ldap group attribute from where retrieving cohort name';
+$string['group_filter'] = 'Group filter';
+$string['group_filter_desc'] = 'Reduce your resultset by applying a group filter';
+$string['group_use_advanced_ldap_filter'] = 'Use an advanced ldap group filter';
+$string['group_use_advanced_ldap_filter_desc'] = 'Whole ldap group filter';
+$string['group_advanced_filter'] = 'Advanced ldap group filter';
+$string['group_advanced_filter_desc'] = 'Custom ldap group filter (rfc2254) ex:(cn=*)';
+$string['group_contexts'] = 'Group contexts';
+$string['group_contexts_desc'] = 'Ldap contexts where retrieving groups';
+$string['cohort_name_suffix'] = 'Cohort name suffix';
+$string['cohort_name_suffix_desc'] = 'To identify cohorts created with this plugin (Useful for not deleting manuals cohorts)';
+$string['cohortsdeltask'] = 'Delete cohorts from non existing LDAP groups';
+//#->
 $string['group_class_desc'] = 'Set if your groups are of another class such as group, groupOfNames...';
+$string['group_class'] = 'Group class';
 $string['groupsynctask'] = 'Synchronize cohorts from LDAP groups';
 $string['pluginname'] = 'LDAP syncing scripts';
 $string['privacy:metadata'] = 'The LDAP syncing scripts do not store any data.';
-$string['process_nested_groups'] = 'Process nested groups';
 $string['process_nested_groups_desc'] = 'If selected, LDAP groups included in groups will be processed';
-$string['real_user_attribute'] = 'Real user class';
+$string['process_nested_groups'] = 'Process nested groups';
 $string['real_user_attribute_desc'] = 'Use if your user_attribute is in mixed case in LDAP (sAMAccountName), but not in Moodle\'s CAS/LDAP settings';
-$string['synccohortattribute'] = 'Sync Moodle\'s cohorts with LDAP attribute';
+$string['real_user_attribute'] = 'Real user class';
 $string['synccohortattribute_info'] = '';
-$string['synccohortgroup'] = 'Sync Moodle\'s cohorts with LDAP groups';
+$string['synccohortattribute'] = 'Sync Moodle\'s cohorts with LDAP attribute';
 $string['synccohortgroup_info'] = '';
+$string['synccohortgroup'] = 'Sync Moodle\'s cohorts with LDAP groups';

--- a/lang/fr/local_ldap.php
+++ b/lang/fr/local_ldap.php
@@ -1,0 +1,43 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * local_ldap language strings.
+ *
+ * @package   local_ldap
+ * @copyright 2013 Patrick Pollet
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+
+//#<-
+$string['cohort_synching_ldap_groups_create_cohort_name_by_attribute'] = 'Créer les noms de cohorte à partir d\'un attribut personnalisé de groupe ldap';
+$string['cohort_synching_ldap_groups_create_cohort_name_by_attribute_desc'] = 'Utiliser l\'attribut sélectionné pour le nom de cohort au lieu du nom du groupe (cn) ';
+$string['group_attribute_description'] = 'Attribut personnalisé de nommage des cohortes';
+$string['group_attribute_description_desc'] = 'Attribut du groupe Ldap à partir duquel on détermine le nom de la cohorte';
+$string['group_filter'] = 'Filtre de groupe simple';
+$string['group_filter_desc'] = 'Restreint la recherche ldap de groupes en appliquant ce filtre ldap simple';
+$string['group_use_advanced_ldap_filter'] = 'Utiliser un filtre de groupe ldap avancé';
+$string['group_use_advanced_ldap_filter_desc'] = 'Utiliser un filtre de groupe ldap avancé';
+$string['group_advanced_filter'] = 'Filtre de groupe ldap avancé';
+$string['group_advanced_filter_desc'] = 'Expression personnalisée de recherche de groupe ldap (rfc2254) ex:(cn=*)';
+$string['group_contexts'] = 'Context (branche) ldap des groupes';
+$string['group_contexts_desc'] = 'Sélection de contexte(s) ldap (;) comme séparateur';
+$string['cohort_name_suffix'] = 'Suffixe de nom de cohorte';
+$string['cohort_name_suffix_desc'] = 'Pour identifier les cohortes créées par le plugin (Utile lors de la purge afin de ne pas supprimer les cohortes manuelles)';
+$string['cohortsdeltask'] = 'Suppression des cohortes ne correspondant à aucun groupe ldap en rapport au critère paramétré';
+//#->
+

--- a/settings.php
+++ b/settings.php
@@ -42,6 +42,50 @@ if ($hassiteconfig) {
     $description = get_string($name.'_desc', 'local_ldap');
     $setting = new admin_setting_configtext('local_ldap/'.$name, $title, $description, 'groupOfNames');
     $settings->add($setting);
+	
+	//#<-
+	$name = 'cohort_synching_ldap_groups_create_cohort_name_by_attribute';
+    $title = get_string($name, 'local_ldap');
+    $description = get_string($name.'_desc', 'local_ldap');
+    $setting = new admin_setting_configcheckbox('local_ldap/'.$name, $title, $description, true);
+    $settings->add($setting);
+	
+	$name = 'group_attribute_description';
+    $title = get_string($name, 'local_ldap');
+    $description = get_string($name.'_desc', 'local_ldap');
+    $setting = new admin_setting_configtext('local_ldap/'.$name, $title, $description, 'description');
+    $settings->add($setting);
+		
+	$name = 'group_use_advanced_ldap_filter';
+    $title = get_string($name, 'local_ldap');
+    $description = get_string($name.'_desc', 'local_ldap');
+    $setting = new admin_setting_configcheckbox('local_ldap/'.$name, $title, $description, false);
+    $settings->add($setting);
+	
+	$name = 'group_advanced_filter';
+    $title = get_string($name, 'local_ldap');
+    $description = get_string($name.'_desc', 'local_ldap');
+    $setting = new admin_setting_configtext('local_ldap/'.$name, $title, $description, '');
+    $settings->add($setting);
+	
+	$name = 'group_filter';
+    $title = get_string($name, 'local_ldap');
+    $description = get_string($name.'_desc', 'local_ldap');
+    $setting = new admin_setting_configtext('local_ldap/'.$name, $title, $description, '*');
+    $settings->add($setting);
+	
+	$name = 'group_contexts';
+    $title = get_string($name, 'local_ldap');
+    $description = get_string($name.'_desc', 'local_ldap');
+    $setting = new admin_setting_configtext('local_ldap/'.$name, $title, $description, '');
+    $settings->add($setting);
+
+    $name = 'cohort_name_suffix';
+    $title = get_string($name, 'local_ldap');
+    $description = get_string($name.'_desc', 'local_ldap');
+    $setting = new admin_setting_configtext('local_ldap/'.$name, $title, $description, '_MDL');
+    $settings->add($setting);
+	//#->
 
     $name = 'real_user_attribute';
     $title = get_string($name, 'local_ldap');


### PR DESCRIPTION
This plugin is very usefull, and that's the way we want to create cohorts from our school information system in Moodle.
But we needed to select the ldap group context to specify where the ldap groups are stored.
We also wanted to delete all obsolete groups at the end of the year but nothing else than "automatic" cohorts, then we add the possibility do "Flag" automatics cohorts with a suffixe and add the procedure task to delete them.
Finally we added the ability to use another attribute than "cn" of the ldap group to name the cohort, which makes cohort names more readable. 
Nothing has been changed for cohort creation by attribute.


ADDITIONAL FEATURES FOR MOODLE_LOCAL_LDAP PLUGIN

- Select the LDAP branch for group storage (new parameter).
- Select the LDAP group attribute to name the cohort in Moodle (new parameter).
- Select a suffix to distinguish automatic cohorts (useful for processing and deleting them) (new parameter).
- Create a simple filter (simple value) to filter LDAP groups that will be synchronized (new parameter).
- Create a complex filter (LDAP filter) to filter LDAP groups that will be synchronized (new parameter).
- Create a procedure to delete cohorts (with suffixes) that do not correspond to any group determined by the active filter.
- Create a schedulable task to purge automatic cohorts by group (new schedulable task).